### PR TITLE
TypeScript Updates + Remove color normalization + Expose Utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint:fix:prettier": "prettier --write \"**/*.{ts,js,cjs,md}\"",
     "lint:eslint": "eslint .",
     "lint:fix:eslint": "eslint --fix .",
-    "build": "rollup -c",
+    "build": "npm run tsc && rollup -c",
     "tsc": "tsc",
     "watch": "tsc -w",
     "dev": "concurrently -c \"auto\" \"npm:watch\" \"npm:vite\"",
@@ -65,8 +65,8 @@
     "*.{js,cjs,md}": "prettier --write"
   },
   "dependencies": {
-    "@lightningjs/solid": "file:./",
-    "@lightningjs/renderer": "^0.3.6"
+    "@lightningjs/renderer": "^0.4.0",
+    "@lightningjs/solid": "file:./"
   },
   "peerDependencies": {
     "solid-js": "*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: 5.3
 
 specifiers:
-  '@lightningjs/renderer': ^0.3.6
+  '@lightningjs/renderer': ^0.4.0
   '@lightningjs/solid': file:./
   '@typescript-eslint/eslint-plugin': ^6.3.0
   '@typescript-eslint/parser': ^6.3.0
@@ -18,7 +18,7 @@ specifiers:
   vite-tsconfig-paths: ^4.2.0
 
 dependencies:
-  '@lightningjs/renderer': 0.3.6
+  '@lightningjs/renderer': 0.4.0
   '@lightningjs/solid': 'link:'
 
 devDependencies:
@@ -1565,8 +1565,8 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /@lightningjs/renderer/0.3.6:
-    resolution: {integrity: sha512-cw+QrptWQ2Nj5QAc9vQGRu7jgjaiUXqxUuAcYiaAUM9sYJhpEpNzYkzaPMiQvv5Mo4hRRI1zgZdnmQ7qZgJq5A==}
+  /@lightningjs/renderer/0.4.0:
+    resolution: {integrity: sha512-95I9pQj9WtbpcDuTkfPAlIUwhF1k/Y8jWhn0qjDbAiv8uwWEL5kvSeItPGoKwd7BYqL1iqlfzsOrkeQd7V8JKQ==}
     dependencies:
       '@lightningjs/threadx': 0.3.3
       '@protobufjs/eventemitter': 1.1.0

--- a/src/components/Canvas.tsx
+++ b/src/components/Canvas.tsx
@@ -35,7 +35,7 @@ export interface CanvasOptions {
 }
 
 export interface CanvasProps {
-  options?: SolidRendererOptions;
+  options?: Partial<SolidRendererOptions>;
   children?: any;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,16 +17,13 @@
  * limitations under the License.
  */
 
+import type { AnimationSettings } from '@lightningjs/renderer';
+import type { IntrinsicTextNodeStyleProps } from './intrinsicTypes.js';
+
 interface Config {
   debug: boolean;
-  animationSettings: {
-    duration: number;
-    easing: string;
-  };
-  fontSettings: {
-    fontFamily: string;
-    fontSize: number;
-  };
+  animationSettings: Partial<AnimationSettings>;
+  fontSettings: Partial<IntrinsicTextNodeStyleProps>;
 }
 
 export const config: Config = {

--- a/src/core/render.ts
+++ b/src/core/render.ts
@@ -22,6 +22,7 @@ import universalInspector, {
   attachInspector,
 } from './universal/dom-inspector.js';
 import type { SolidNode } from './node/index.js';
+import type { JSX } from 'solid-js';
 
 const loadInspector = import.meta?.env?.MODE === 'development';
 if (loadInspector) {
@@ -30,8 +31,15 @@ if (loadInspector) {
 const solidRenderer = createRenderer<SolidNode>(
   loadInspector ? universalInspector : universalLightning,
 );
+
+// TODO: This is a hack to get the `render()` function to work as it is used now in the demo app
+// There's gotta be a better way to fix it
+export const render = solidRenderer.render as unknown as (
+  code: () => JSX.Element,
+  node?: SolidNode,
+) => () => void;
+
 export const {
-  render,
   effect,
   memo,
   createComponent,

--- a/src/core/universal/dom-inspector.ts
+++ b/src/core/universal/dom-inspector.ts
@@ -18,6 +18,7 @@
 import universalLightning, { type SolidRendererOptions } from './lightning.js';
 import { renderer } from '../renderer/index.js';
 import type { ElementNode, SolidNode, TextNode } from '../node/index.js';
+import { assertTruthy } from '@lightningjs/renderer/utils';
 
 const injectCSS = (css: string) => {
   const el = document.createElement('style');
@@ -58,7 +59,6 @@ export function attachInspector() {
   `);
 
   setTimeout(function () {
-    // @ts-expect-error Remove when Renderer publicizes `canvas`
     updateRootStyleFromCanvas(renderer.canvas);
   }, 1000);
 }
@@ -70,7 +70,7 @@ export default {
 
     if (name === 'canvas') {
       dom.id = 'linspector';
-      // @ts-expect-error Remove when Renderer publicizes `canvas`
+      assertTruthy(renderer.canvas.parentNode);
       renderer.canvas.parentNode.appendChild(dom);
     } else {
       dom.classList.add('lnode');

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -19,23 +19,6 @@
 import { config } from '../config.js';
 import type { SolidNode } from './node/index.js';
 
-export function normalizeColor(color: string | number = '') {
-  if (isInteger(color)) {
-    return color;
-  }
-
-  if (typeof color === 'string') {
-    // Renderer expects RGBA values
-    if (color.startsWith('#')) {
-      return color.replace('#', '0x') + (color.length === 7 ? 'ff' : '');
-    }
-
-    if (color.startsWith('0x')) {
-      return color;
-    }
-    return '0x' + (color.length === 6 ? color + 'ff' : color);
-  }
-}
 const isDev = import.meta?.env?.MODE === 'development';
 export function log(msg: string, node: SolidNode, ...args: any[]) {
   if (isDev) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,3 +32,4 @@ export * from './core/render.js';
 export { config as Config } from './config.js';
 export * from './core/node/index.js';
 export * from './intrinsicTypes.js';
+export * from './utils.js';

--- a/src/intrinsicTypes.ts
+++ b/src/intrinsicTypes.ts
@@ -1,10 +1,35 @@
+/*
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import {
+  type AnimationSettings,
   type Dimensions,
   type INode,
   type INodeWritableProps,
   type ITextNodeWritableProps,
 } from '@lightningjs/renderer';
 import { type ElementNode, type TextNode } from './core/node/index.js';
+
+export interface BorderStyleObject {
+  width: number;
+  color: number;
+}
+
+export type BorderStyle = number | BorderStyleObject;
 
 export interface IntrinsicCommonProps {
   ref?: any;
@@ -29,16 +54,34 @@ export interface IntrinsicCommonProps {
   id?: string;
   flexDirection?: 'row' | 'column';
   selected?: number | null;
+  borderRadius?: number;
+  border?: BorderStyle;
+  borderLeft?: BorderStyle;
+  borderRight?: BorderStyle;
+  borderTop?: BorderStyle;
+  borderBottom?: BorderStyle;
 }
 
-export interface IntrinsicTextProps
-  extends Partial<Omit<ITextNodeWritableProps, 'parent' | 'shader'>>,
-    IntrinsicCommonProps {
-  style?: Partial<Omit<ITextNodeWritableProps, 'parent' | 'shader'>>;
-}
+// TODO: Add this concept back in and come up with a way to properly type it so it works
+// internally and externally.
+//
+// Type that transforms all number typed properties to a tuple
+// type TransformAnimatableNumberProps<T> = {
+//   [K in keyof T]: number extends T[K] ? (number | [value: number, settings: AnimationSettings]) : T[K];
+// };
 
-export interface IntrinsicNodeProps
+export interface IntrinsicNodeStyleProps
   extends Partial<Omit<INodeWritableProps, 'parent' | 'shader'>>,
-    IntrinsicCommonProps {
-  style?: Partial<Omit<INodeWritableProps, 'parent' | 'shader'>>;
+    IntrinsicCommonProps {}
+
+export interface IntrinsicTextNodeStyleProps
+  extends Partial<Omit<ITextNodeWritableProps, 'parent' | 'shader'>>,
+    IntrinsicCommonProps {}
+
+export interface IntrinsicNodeProps extends IntrinsicNodeStyleProps {
+  style?: IntrinsicNodeStyleProps;
+}
+
+export interface IntrinsicTextProps extends IntrinsicTextNodeStyleProps {
+  style?: IntrinsicTextNodeStyleProps;
 }

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 /* eslint-disable @typescript-eslint/no-namespace */
 import {
   type IntrinsicNodeProps,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Comcast Cable Communications Management, LLC
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isInteger } from './core/utils.js';
+
+/**
+ * Converts a color string to a color number value.
+ */
+export function hexColor(color: string | number = ''): number {
+  if (isInteger(color)) {
+    return color;
+  }
+
+  if (typeof color === 'string') {
+    // Renderer expects RGBA values
+    if (color.startsWith('#')) {
+      return Number(
+        color.replace('#', '0x') + (color.length === 7 ? 'ff' : ''),
+      );
+    }
+
+    if (color.startsWith('0x')) {
+      return Number(color);
+    }
+    return Number('0x' + (color.length === 6 ? color + 'ff' : color));
+  }
+
+  return 0x00000000;
+}
+
+/**
+ * Converts degrees to radians
+ */
+export function deg2rad(deg: number) {
+  return (deg * Math.PI) / 180;
+}


### PR DESCRIPTION
- Various TypeScript updates
- Breaking Change: Removed the automatic normalization of colors from strings to numbers
  - Colors must be specified as numbers only now
  - Applications may use the newly exposed `hexColor()` method if they wish to use string formatted colors.
- Expose `hexColor()` and `degToRad()` util methods