### PR TITLE
move style states under $states object

### DIFF
--- a/docs/states.md
+++ b/docs/states.md
@@ -11,13 +11,15 @@ const Button = {
   color: 0x546160ff,
   alpha: 0.8,
   scale: 1,
-  focus: {
-    color: 0x58807dff,
-    scale: 1.1,
-    alpha: 1,
-  },
-  disabled: {
-    color: 0x333333ff,
+  $states: {
+    focus: {
+      color: 0x58807dff,
+      scale: 1.1,
+      alpha: 1,
+    },
+    disabled: {
+      color: 0x333333ff,
+    },
   },
 };
 ```
@@ -69,7 +71,7 @@ Config.stateMapperHook = (node, states) => {
 };
 ```
 
-Then it would apply `focusbrand` from the styles object.
+Then it would apply `focusbrand` from the styles $states object.
 
 ## forwardStates
 
@@ -87,10 +89,12 @@ function Button(props) {
       scale: { duration: 1500, delay: 200, easing: 'easy-in' },
       alpha: { duration: 1500, delay: 200, easing: 'easy-in' },
     },
-    focus: {
-      color: [0x58807dff, { duration: 2000 }],
-      scale: 1.2,
-      alpha: 1,
+    $states: {
+      focus: {
+        color: [0x58807dff, { duration: 2000 }],
+        scale: 1.2,
+        alpha: 1,
+      },
     },
   };
 
@@ -103,8 +107,10 @@ function Button(props) {
     color: 0xf6f6f9ff,
     height: Button.height,
     width: Button.width,
-    focus: {
-      color: 0xffffffff,
+    $states: {
+      focus: {
+        color: 0xffffffff,
+      },
     },
   };
 

--- a/src/core/node/index.ts
+++ b/src/core/node/index.ts
@@ -503,7 +503,10 @@ export class ElementNode extends Object {
 
     const states = config.stateMapperHook?.(this, this.states) || this.states;
 
-    if (this._undoStates || (this.style && keyExists(this.style, states))) {
+    if (
+      this._undoStates ||
+      (this.style?.$states && keyExists(this.style.$states, states))
+    ) {
       this._undoStates = this._undoStates || {};
       let stylesToUndo = {};
 
@@ -518,7 +521,7 @@ export class ElementNode extends Object {
       }
 
       const newStyles = states.reduce((acc, state) => {
-        const styles = this.style[state];
+        const styles = this.style.$states![state];
         if (styles) {
           acc = {
             ...acc,

--- a/src/intrinsicTypes.ts
+++ b/src/intrinsicTypes.ts
@@ -81,6 +81,7 @@ export interface IntrinsicNodeStyleCommonProps {
   marginLeft?: number;
   marginRight?: number;
   marginTop?: number;
+  $states?: Record<string, IntrinsicNodeStyleProps>;
   transition?:
     | Record<string, Partial<AnimationSettings> | true | false>
     | true
@@ -92,6 +93,7 @@ export interface IntrinsicTextStyleCommonProps {
   marginRight?: number;
   marginTop?: number;
   marginBottom?: number;
+  $states?: Record<string, IntrinsicNodeStyleProps>;
 }
 
 export interface IntrinsicCommonProps


### PR DESCRIPTION
Two reasons for this:

1. Code clarity have $states to house all possible states for a component to make it clear this is not being done by the renderer
2. The ui-components add ~8 states for every component which would add a bunch of additional keys to process - so grouping them will reduce that overhead