### PR TITLE
fix: update color to accept a number or a string

### DIFF
--- a/src/core/node/index.ts
+++ b/src/core/node/index.ts
@@ -66,7 +66,7 @@ function borderAccessor(
   direction: '' | 'Top' | 'Right' | 'Bottom' | 'Left' = '',
 ) {
   return {
-    set(this: ElementNode, value: number | { width: number; color: number }) {
+    set(this: ElementNode, value: number | { width: number; color: number | string }) {
       // Format: width || { width, color }
       if (isNumber(value)) {
         value = { width: value, color: 0x000000ff };
@@ -191,7 +191,7 @@ export class ElementNode extends Object {
   private _animationSettings?: Partial<AnimationSettings>;
   private _width?: number;
   private _height?: number;
-  private _color?: number;
+  private _color?: number | string;
   public _borderRadius?: number;
   public _border?: BorderStyleObject;
   public _borderLeft?: BorderStyleObject;

--- a/src/intrinsicTypes.ts
+++ b/src/intrinsicTypes.ts
@@ -40,7 +40,7 @@ type AddUndefined<T> = {
 
 export interface BorderStyleObject {
   width: number;
-  color: number;
+  color: number | string;
 }
 
 export type BorderStyle = number | BorderStyleObject;


### PR DESCRIPTION
This PR updates the node `color` property type to `number | string`. Currently, it's limited to `number` but this doesn't correctly reflect the underlying javascript as we're able to pass strings to color throughout ui-components without any issue. This would help clear up a whole bunch of type errors in ui-components, as well as more correctly reflect a node's API.

Note: I'm not actually sure if the updates to `src/core/node/index.ts` are required but I made them just in case