### PR TITLE
fix: update SolidStyles type to include state style objects

### DIFF
--- a/packages/core/node/elementNode.ts
+++ b/packages/core/node/elementNode.ts
@@ -166,7 +166,8 @@ export interface TextNode {
 }
 
 export type SolidNode = ElementNode | TextNode;
-export type SolidStyles = NodeStyles | TextStyles;
+
+export type SolidStyles = {[key: string]:  NodeStyles | TextStyles} & (NodeStyles | TextStyles);
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface ElementNode


### PR DESCRIPTION
This PR resolves a type issue in the `ElementNode._stateChanged` method by updating `SolidStyles` to include a mapped type that defines the state style objects